### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Use trusty environment for a up-to-date version of autotools
+sudo: required
+dist: trusty
 language: c
 os:
   - linux
@@ -7,6 +10,6 @@ compiler:
   - gcc
 script:
   - ./autogen.sh
-  - ./configure
+  - ./configure || (cat config.log; exit 1)
   - make || exit 1
   - make check || (cat test-suite.log; exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+os:
+  - linux
+  - osx
+compiler:
+  - clang
+  - gcc
+script:
+  - ./autogen.sh
+  - ./configure
+  - make || exit 1
+  - make check || (cat test-suite.log; exit 1)

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
       tests/43.t
 TEST_EXTENSIONS=.t
-T_LOG_COMPILER=sh $(top_srcdir)/tests/test.sh
+T_LOG_COMPILER=$(top_srcdir)/tests/test.sh
 check_PROGRAMS=tests/pick-test
 tests_pick_test_SOURCES=$(TESTS) tests/test.sh tests/pick-test.c
 # Required by posix_openpt on Linux.

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,9 +16,9 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
       tests/43.t
 TEST_EXTENSIONS=.t
-T_LOG_COMPILER=$(top_srcdir)/tests/test.sh
+T_LOG_COMPILER=tests/test.sh
 check_PROGRAMS=tests/pick-test
-tests_pick_test_SOURCES=$(TESTS) tests/test.sh tests/pick-test.c
+tests_pick_test_SOURCES=tests/pick-test.c
 # Required by posix_openpt on Linux.
 tests_pick_test_CFLAGS=-D_XOPEN_SOURCE=600
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 usage() {
   echo "usage: sh tests/test.sh file ..." 1>&2
   exit 1


### PR DESCRIPTION
This is an attempt to prevent regression like the one I managed to
introduce in 1.5.0, where the tests could not run on Linux. Travis is
capable of building on both Linux and macOS. Here's a first attempt to
configure Travis. However, I don't have the privilegies needed to enable
Travis, ping @mike-burns and @calleerlandsson.