### PR TITLE
Make linking against ncursesw opt-in

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,16 +9,13 @@ AC_TYPE_SSIZE_T
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memmove pledge reallocarray setlocale strdup])
-AC_SEARCH_LIBS([initscr], [ncursesw ncurses], [], [
-  AC_MSG_ERROR([unable to find initscr() function. Try to install ncurses])
-])
-
-AC_TRY_LINK([
-	#include <ncursesw/curses.h>
-	#include <ncursesw/term.h>
-], [], [
-AC_DEFINE(HAVE_NCURSESW_H,, Define if ncursesw is available)
-])
-
+AC_SEARCH_LIBS([setupterm], [curses], [],
+  [
+    AC_SEARCH_LIBS([setupterm], [ncursesw],
+      [AC_DEFINE([HAVE_NCURSESW_H], [1], [Define if ncursesw is available])],
+      [AC_MSG_ERROR([unable to find setupterm function])]
+    )
+  ]
+)
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
I've always found it odd that pick favors linking against ncursesw if
present instead of curses. This gets even more interesting on my machine
where the ncursesw library is present but not the headers. This means in
practice: the curses headers are used but later linked against ncursesw.
However, it does work since ncursesw implements the same API as curses.

My proposal is to make linking against ncursesw a opt-in feature since
the more common curses library should be favored if available.

This patch adds a `--{with,without}-ncursesw` option to the configure
command, which defaults to false. The change is therefore breaking in
sense that users with only ncursesw available has to pass the new option
while running configure. A reasonable compromise in my opinion since
less implicit dependency resolving is a good thing. Worth mention: the
major of the users will not notice this change if curses is available
(most likely).

If I where to decide I would go even further and trust the user: if the
ncursesw option is given, assume the both headers and libraries are
present. Much of the autoconf verification could then be dropped -> less
code to maintain.

Left-over notes:

- I'm planning on running Travis with and without ncursesw

- Any advice or convention on how the format all the parenthesis and
  brackets inside `configure.ac` would be appreciated

Thoughts @calleerlandsson and @mike-burns?