### PR TITLE
Run distcheck in favor of check on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
   - ./autogen.sh
   - ./configure || (cat config.log; exit 1)
   - make || exit 1
-  - make check || (cat test-suite.log; exit 1)
+  - make distcheck || (cat test-suite.log; exit 1)


### PR DESCRIPTION
In addition to running the test suite (just like the `check` Make
target), the `distcheck` target also takes the following steps to test
the distribution:

- tries to do a `VPATH` build, with the `srcdir` and all its content
  made read-only;
- installs the package in a temporary directory (with `make install`),
  and tries runs the test suite on the resulting installation (with
  `make installcheck`);
- checks that the package can be correctly uninstalled (by `make
  uninstall`) and cleaned (by `make distclean`);
- finally, makes another tarball to ensure the distribution is
  self-contained.

For more info, see https://www.gnu.org/software/automake/manual/html_node/Checking-the-Distribution.html