### PR TITLE
Use a non-personal email for the project

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,7 +25,7 @@ Release
 
 1. Update the version in `configure.ac`:
 
-        AC_INIT([pick], [0.0.2], [calle@calleerlandsson.com])
+        AC_INIT([pick], [0.0.2], [pick-maintainers@calleerlandsson.com])
 
 2. Verify the tarball:
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([pick], [1.5.2], [calle@calleerlandsson.com])
+AC_INIT([pick], [1.5.2], [pick-maintainers@calleerlandsson.com])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC


### PR DESCRIPTION
This prevents me from becoming a bottleneck in communications.

@mptre, @mike-burns: if you think the maintainers email idea mentioned in #170 is good, maybe this could also be an improvement?