### PR TITLE
Fix underline spill over bug

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -717,8 +717,9 @@ print_line(const char *string, size_t length, int so, ssize_t ulso, ssize_t uleo
 		if (tty_putc(' ') == EOF)
 			err(1, "tty_putc");
 
-	if (so)
-		tty_putp(exit_standout_mode, 1);
+	/* If uleo is greater than columns the underline attribute will spill
+	 * over on the next line unless all attributes are exited. */
+	tty_putp(exit_attribute_mode, 1);
 }
 
 /*


### PR DESCRIPTION
If the end of the match is greater than the number of columns the
underline attribute will spill over on the next line since it's never
exited. Running the following command before/after applying this commit
highlights the bug:

```sh
for _ in 0 1; do
  jot -n -s '' $(($COLUMNS - 1)) 0 0
  echo ab
done | pick -q ab
```