### PR TITLE
Don't normalize score with length of choice

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -547,7 +547,7 @@ score(struct choice *choice)
 	}
 
 	match_length = choice->match_end - choice->match_start;
-	choice->score = (float)query_length / match_length / choice->length;
+	choice->score = (float)query_length/match_length;
 }
 
 size_t

--- a/tests/08.t
+++ b/tests/08.t
@@ -6,4 +6,4 @@ ABC
 AB
 A
 stdout:
-A
+ABC

--- a/tests/36.t
+++ b/tests/36.t
@@ -1,7 +1,7 @@
 description: delete til cursor
 keys: abc \002 \025 \\n # LEFT CTLR_U ENTER
 stdin:
-abc
 c
+abc
 stdout:
 c


### PR DESCRIPTION
The purpose of this PR is to lay the foundation for a discussion. I
believe a discussion always should start with a patch.

Why is the score normalized with the length of the choice? This
implies that shorter choices should be favored.

In the following scenario, I would assume `abc, a` would be the order
of the choices with the query `a`:

``` sh
printf 'abc\na\n' | pick -q a
```
