### PR TITLE
Only define __dead if it's missing

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -5,19 +5,9 @@
 #include "config.h"
 #endif
 
-#ifdef __FreeBSD__
-#define __dead __dead2
-#endif /* __FreeBSD__ */
-
-#if defined(__linux__) || defined(__CYGWIN__)
 #ifndef __dead
-#ifdef __GNUC__
-#define __dead		__attribute__((__noreturn__))
-#else
 #define __dead
 #endif
-#endif
-#endif /* __linux__ || __CYGWIN__ */
 
 #ifndef HAVE_REALLOCARRAY
 


### PR DESCRIPTION
I propose we only define `__dead` to the empty string if it's missing
since the current `ifdef`-logic is rather complex and we don't want to
maintain support for all various platforms and compilers.