### PR TITLE
Stop maintaining the Arch Linux package

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -55,7 +55,6 @@ Release
 7. Contact package maintainers:
 
 * Aggelos Avgerinos <evaggelos.avgerinos@gmail.com> (Debian & Ubuntu)
-* Calle Erlandsson <calle@calleerlandsson.com> (Arch Linux)
 * Chunyang Xu <xuchunyang.me@gmail.com> (MacPorts)
 * Fredrik Fornwall <fredrik@fornwall.net> (Homebrew)
 * Neel Chauhan <neel@neelc.org> (FreeBSD)

--- a/README.md
+++ b/README.md
@@ -7,17 +7,6 @@ using an interface with fuzzy search functionality.
 
 ## Installation
 
-### Arch Linux
-
-A package for Pick is available in [the AUR].
-
-```sh
-curl -O https://aur.archlinux.org/cgit/aur.git/snapshot/pick.tar.gz
-tar -xzf pick.tar.gz
-cd pick
-makepkg -sri
-```
-
 ### Debian and Ubuntu
 
 A package for Pick is available as of [Debian 9] and [Ubuntu 15.10].
@@ -70,7 +59,6 @@ cd pick-VERSION
 less INSTALL.md
 ```
 
-[the AUR]: https://aur.archlinux.org/packages/pick/
 [Debian 9]: https://packages.debian.org/stretch/pick
 [Ubuntu 15.10]: http://packages.ubuntu.com/wily/pick
 [the releases page]: https://github.com/calleerlandsson/pick/releases/


### PR DESCRIPTION
I haven't been running Arch Linux for a while now. Therefor, maintaining the Arch package has been a bit of a hassle to the extent of it falling behind a version.

If someone wants to to take over maintaining the package I would appreciate it a lot and transfer ownership of the AUR package. If not, I'll disown the package on the AUR site and someone else can pick it up in the future.

Let's let this PR sit for at least a week before merging.