### PR TITLE
Calculate the width of each displayed character

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 AUTOMAKE_OPTIONS=foreign
 
 AM_CFLAGS=-pedantic -Wall -Werror -Wextra
+AM_CPPFLAGS=-D_GNU_SOURCE
 
 bin_PROGRAMS=pick
 dist_pick_SOURCES=pick.c compat.h compat.c
@@ -19,8 +20,6 @@ T_LOG_COMPILER=$(top_srcdir)/tests/pick-test.sh
 check_PROGRAMS=tests/pick-test
 tests_pick_test_SOURCES=tests/pick-test.c
 tests_pick_test_CFLAGS=$(AM_CFLAGS)
-# Required by posix_openpt on Linux.
-tests_pick_test_CFLAGS+=-D_XOPEN_SOURCE=600
 
 EXTRA_DIST=INSTALL.md INSTALL.md.in LICENSE README.md tests/pick-test.sh $(TESTS)
 


### PR DESCRIPTION
In an attempt to fix #184 caused by lines including Unicode characters
that occupy more than one column.

While at it, fix another bug related to the column counter when a line
contains more than one escape sequence.

Reviews and testing would be much appreciated I haven't discovered any
regression nor performance decrease running this diff so far.

/cc @calleerlandsson @mike-burns @teoljungberg.