### PR TITLE
Fix tab output bug

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -690,11 +690,13 @@ print_line(const char *str, size_t len, int standout,
 			width = 8 - (col & 7);	/* ceil to multiple of 8 */
 			if (col + width > columns)
 				break;
+			col += width;
+
 			for (; width > 0; width--)
 				if (tty_putc(' ') == ERR)
 					err(1, "tty_putc");
 
-			i++, col += width;
+			i++;
 			continue;
 		}
 


### PR DESCRIPTION
Increment the column counter prior decrementing the calculated width of
the tab.

Regression introduced in commit 369350b (Calculate the width of each
displayed character).

Sorry, can we do a patch release @calleerlandsson?