### PR TITLE
Add redraw-function with Ctrl-L

### DIFF
--- a/pick.1
+++ b/pick.1
@@ -78,6 +78,8 @@ input field.
 Delete to the beginning of the line in the search query input field.
 .It Ic Ctrl-K
 Delete to the end of the line in the search query input field.
+.It Ic Ctrl-L
+Redraw all choices and move the selection to the first choice.
 .It Ic Printable characters
 Added to the search query and will refine the current search.
 .El

--- a/pick.c
+++ b/pick.c
@@ -39,6 +39,7 @@ enum key {
 	CTRL_A,
 	CTRL_E,
 	CTRL_K,
+	CTRL_L,
 	CTRL_U,
 	CTRL_W,
 	UP,
@@ -396,6 +397,11 @@ selected_choice(void)
 			    query_length);
 			query_length = cursor_position;
 			filter_choices();
+			selection = yscroll = 0;
+			break;
+		case CTRL_L:
+			restartterm((char *)0, fileno(tty_out), (int *)0);
+			choices_lines = lines - 1;
 			selection = yscroll = 0;
 			break;
 		case CTRL_W:
@@ -822,6 +828,7 @@ get_key(char *buf, size_t size, size_t *nread)
 		KEY(CTRL_A,	"\001"),
 		KEY(CTRL_E,	"\005"),
 		KEY(CTRL_K,	"\013"),
+		KEY(CTRL_L,	"\014"),
 		KEY(CTRL_U,	"\025"),
 		KEY(CTRL_W,	"\027"),
 		KEY(DEL,	"\004"),


### PR DESCRIPTION
Instead of checking the position of the "selection bar" and setting "yscroll" accordingly, both are set to zero: if the display is already messed up by resizing the terminal window, it's IMHO better to start over ... ;-)