### PR TITLE
Declare handle_sigint as dead

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -67,7 +67,7 @@ static char			*eager_strpbrk(const char *, const char *);
 static void			 filter_choices(void);
 static char			*get_choices(void);
 static enum key			 get_key(char *, size_t, size_t *);
-static void			 handle_sigint(int);
+__dead static void		 handle_sigint(int);
 static int			 isu8cont(unsigned char);
 static int			 isu8start(unsigned char);
 static size_t			 min_match(const char *, size_t, ssize_t *,
@@ -664,7 +664,7 @@ tty_putc(int c)
 	return putc(c, tty_out);
 }
 
-void
+__dead void
 handle_sigint(int sig __attribute__((unused)))
 {
 	tty_restore();


### PR DESCRIPTION
Not really necessary, but `usage` is also declared as dead ...