### PR TITLE
Add support for NetBSD-curses

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -9,6 +9,11 @@
 #define __dead __dead2
 #endif /* __FreeBSD__ */
 
+#ifdef __NetBSD__
+#define tparm(a, b)	tparm(a, b, 0, 0, 0, 0, 0, 0, 0, 0)
+#define UP		_UP
+#endif
+
 #if defined(__linux__) || defined(__CYGWIN__)
 #ifndef __dead
 #ifdef __GNUC__


### PR DESCRIPTION
NetBSD uses `curses`: `tparm` with 9 parameters and `UP` already defined in `termcap.h`
(Tested with NetBSD 7.1 ... NetBSD 5.1 lacks some definitions in `term.h` and breaks ...)