### PR TITLE
Fix compile warning on isprint()-call

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -884,7 +884,7 @@ get_key(char *buf, size_t size, size_t *nread)
 	}
 
 	if (!isu8start(buf[0])) {
-		if (isprint(buf[0]))
+		if (isprint((unsigned char)buf[0]))
 			return PRINTABLE;
 
 		return UNKNOWN;


### PR DESCRIPTION
On some platforms (NetBSD 7.1 with gcc 4.8.5) the following warning appears:
```
pick.c: In function 'get_key':
pick.c:887:3: warning: array subscript has type 'char' [-Wchar-subscripts]
   if (isprint(buf[0]))
   ^
```
and due to `-Werror` the compilation exits ... this commit fixes it ...
