### PR TITLE
Lower requirements for autoconf and automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,9 @@
-AC_PREREQ([2.69])
+AC_PREREQ([2.61])
 AC_INIT([pick], [1.7.0], [pick-maintainers@calleerlandsson.com])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
+AM_PROG_CC_C_O
 AC_CHECK_FUNCS([pledge reallocarray])
 AC_SEARCH_LIBS([setupterm], [curses], [],
   [


### PR DESCRIPTION
to compile `pick` on ancient installations, uses an obsolete macro but does not hurt ...