### PR TITLE
Use compound-list for POSIX compatibility

### DIFF
--- a/tests/pick-test.sh
+++ b/tests/pick-test.sh
@@ -25,8 +25,8 @@ for testcase; do
       eval "${key}='${val%%#*}'"
     else
       case "$key" in
-      stdin)  tmpfile=$stdin; >$tmpfile ;;
-      stdout) tmpfile=$stdout; >$tmpfile ;;
+      stdin)  { tmpfile=$stdin; >$tmpfile; } ;;
+      stdout) { tmpfile=$stdout; >$tmpfile; } ;;
       *)      printf "${key}\n" >>$tmpfile ;;
       esac
     fi


### PR DESCRIPTION
... or some shells (`sh` on NetBSD) will fail to run the tests ...