### PR TITLE
Add ending semicolon as work-around for NetBSD sh

### DIFF
--- a/tests/pick-test.sh
+++ b/tests/pick-test.sh
@@ -25,8 +25,8 @@ for testcase; do
       eval "${key}='${val%%#*}'"
     else
       case "$key" in
-      stdin)  tmpfile=$stdin; >$tmpfile ;;
-      stdout) tmpfile=$stdout; >$tmpfile ;;
+      stdin)  tmpfile=$stdin; >$tmpfile; ;;
+      stdout) tmpfile=$stdout; >$tmpfile; ;;
       *)      printf "${key}\n" >>$tmpfile ;;
       esac
     fi


### PR DESCRIPTION
... without this all checks fail with `Syntax error: ";;" unexpected` ... don't know why ...