### PR TITLE
Pick elements without interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Swap files
+*.swo
+*.swp
+
 *.o
 core*
 pick

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
       tests/43.t tests/44.t tests/45.t tests/46.t tests/47.t tests/48.t \
       tests/49.t tests/50.t tests/51.t tests/52.t tests/53.t tests/54.t \
-      tests/55.t tests/56.t
+      tests/55.t tests/56.t tests/57.t tests/58.t tests/59.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=$(top_srcdir)/tests/pick-test.sh
 check_PROGRAMS=tests/pick-test

--- a/pick.c
+++ b/pick.c
@@ -160,7 +160,7 @@ main(int argc, char *argv[])
                         break;
                 case 'n':
                         pick_element.type = NTH;
-                        pick_element.index  = atoi(optarg); // it returns '0' by default, which is fine
+                        pick_element.index  = atoi(optarg) - 1; // it returns '0' by default, which is fine
                         break;
 		case 'o':
 			/*
@@ -232,7 +232,7 @@ main(int argc, char *argv[])
 __dead void
 usage(void)
 {
-	fprintf(stderr, "usage: pick [-hvS] [-d [-o]] [-x | -X] [-q query] [-first] [-last] [-nth=<n>]\n"
+	fprintf(stderr, "usage: pick [-hvS] [-d [-o]] [-x | -X] [-q query] [--first] [--last] [--nth n]\n"
 	    "    -h          output this help message and exit\n"
 	    "    -v          output the version and exit\n"
 	    "    -S          disable sorting\n"
@@ -241,9 +241,9 @@ usage(void)
 	    "    -x          enable alternate screen\n"
 	    "    -X          disable alternate screen\n"
 	    "    -q query    supply an initial search query\n"
-            "    -first      pick first element and exit\n"
-            "    -last       pick last  element and exit\n"
-            "    -nth=<n>    pick nth   element and exit\n");
+            "    --first     pick first element and exit\n"
+            "    --last      pick last  element and exit\n"
+            "    --nth n     pick nth   element and exit\n");
 
 	exit(1);
 }

--- a/pick.c
+++ b/pick.c
@@ -59,6 +59,11 @@ enum return_index {
         NTH
 };
 
+struct element {
+        enum return_index type;
+        int pos;
+};
+
 struct choice {
 	const char	*description;
 	const char	*string;
@@ -104,7 +109,7 @@ static size_t		 query_length, query_size;
 static int		 descriptions, choices_lines;
 static int		 sort = 1;
 static int		 use_alternate_screen = 1;
-static enum return_index rtn_idx = NONE;
+static struct element    pick_element;
 
 int
 main(int argc, char *argv[])
@@ -116,6 +121,8 @@ main(int argc, char *argv[])
 	int			 output_description = 0;
 
 	setlocale(LC_CTYPE, "");
+        pick_element.type = NONE;
+        pick_element.pos  = -1;
 
         static struct option long_options[] =
         {
@@ -143,13 +150,16 @@ main(int argc, char *argv[])
 			descriptions = 1;
 			break;
                 case 'e':
-                        rtn_idx = FIRST;
+                        pick_element.type = FIRST;
+                        pick_element.pos  = 0;
                         break;
                 case 'E':
-                        rtn_idx = LAST;
+                        pick_element.type = LAST;
+                        // we do not know what is the last index so far
                         break;
                 case 'n':
-                        rtn_idx = NTH;
+                        pick_element.type = NTH;
+                        pick_element.pos  = atoi(optarg); // it returns '0' by default, which is fine
                         break;
 		case 'o':
 			/*

--- a/pick.c
+++ b/pick.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
-#include <unistd.h>
 #include <wchar.h>
 #include <getopt.h>
 
@@ -112,16 +111,16 @@ main(int argc, char *argv[])
 
         static struct option long_options[] =
         {
-                {"x", no_argument, &use_alternate_screen, 1},
-                {"X", no_argument, &use_alternate_screen, 0},
-                {"S", no_argument, &sort, 0},
-                {"desc", no_argument, 0, 'd'},
-                {"output", no_argument, 0, 'o'},
-                {"query", no_argument, 0, 'q'},
+                {"",        no_argument, 0, 'x'},
+                {"",        no_argument, 0, 'X'},
+                {"",        no_argument, 0, 'S'},
+                {"",        no_argument, 0, 'd'},
+                {"output",  no_argument, 0, 'o'},
+                {"query",   no_argument, 0, 'q'},
                 {"version", no_argument, 0, 'v'},
-                {"first", no_argument,  0, 'e'},
-                {"last", no_argument, 0, 'E'},
-                {"nth", required_argument, 0, 'n'},
+                {"first",   no_argument, 0, 'e'},
+                {"last",    no_argument, 0, 'E'},
+                {"nth",     required_argument, 0, 'n'},
                 {0, 0, 0, 0}
         };
 
@@ -130,7 +129,7 @@ main(int argc, char *argv[])
 		err(1, "pledge");
 #endif
 
-	while ((c = getopt_long(argc, argv, "dhoqv:e:E:n", long_options, &option_index)) != -1)
+	while ((c = getopt_long(argc, argv, "dhoq:SvxX", long_options, &option_index)) != -1)
 		switch (c) {
 		case 'd':
 			descriptions = 1;
@@ -153,9 +152,18 @@ main(int argc, char *argv[])
 			query_length = strlen(query);
 			query_size = query_length + 1;
 			break;
-		case 'v':
+	        case 'S':
+			sort = 0;
+			break;
+           	case 'v':
 			puts(PACKAGE_VERSION);
 			exit(0);
+		case 'x':
+			use_alternate_screen = 1;
+			break;
+		case 'X':
+			use_alternate_screen = 0;
+			break;
 		default:
 			usage();
 		}

--- a/pick.c
+++ b/pick.c
@@ -14,6 +14,7 @@
 #include <termios.h>
 #include <unistd.h>
 #include <wchar.h>
+#include <getopt.h>
 
 #ifdef HAVE_NCURSESW_H
 #include <ncursesw/curses.h>
@@ -104,20 +105,41 @@ main(int argc, char *argv[])
 	const struct choice	*choice;
 	char			*input;
 	int			 c;
+        int                      option_index = 0;
 	int			 output_description = 0;
 
 	setlocale(LC_CTYPE, "");
+
+        static struct option long_options[] =
+        {
+                {"x", no_argument, &use_alternate_screen, 1},
+                {"X", no_argument, &use_alternate_screen, 0},
+                {"S", no_argument, &sort, 0},
+                {"desc", no_argument, 0, 'd'},
+                {"output", no_argument, 0, 'o'},
+                {"query", no_argument, 0, 'q'},
+                {"version", no_argument, 0, 'v'},
+                {"first", no_argument,  0, 'e'},
+                {"last", no_argument, 0, 'E'},
+                {"nth", required_argument, 0, 'n'},
+                {0, 0, 0, 0}
+        };
 
 #ifdef HAVE_PLEDGE
 	if (pledge("stdio tty rpath wpath cpath", NULL) == -1)
 		err(1, "pledge");
 #endif
 
-	while ((c = getopt(argc, argv, "dhoq:SvxX")) != -1)
+	while ((c = getopt_long(argc, argv, "dhoqv:e:E:n", long_options, &option_index)) != -1)
 		switch (c) {
 		case 'd':
 			descriptions = 1;
 			break;
+                case 'e':
+                case 'E':
+                case 'n':
+                        puts("blah");
+                        exit(0);
 		case 'o':
 			/*
 			 * Only output description if descriptions are read and
@@ -131,18 +153,9 @@ main(int argc, char *argv[])
 			query_length = strlen(query);
 			query_size = query_length + 1;
 			break;
-		case 'S':
-			sort = 0;
-			break;
 		case 'v':
 			puts(PACKAGE_VERSION);
 			exit(0);
-		case 'x':
-			use_alternate_screen = 1;
-			break;
-		case 'X':
-			use_alternate_screen = 0;
-			break;
 		default:
 			usage();
 		}
@@ -183,7 +196,7 @@ main(int argc, char *argv[])
 __dead void
 usage(void)
 {
-	fprintf(stderr, "usage: pick [-hvS] [-d [-o]] [-x | -X] [-q query]\n"
+	fprintf(stderr, "usage: pick [-hvS] [-d [-o]] [-x | -X] [-q query] [-first] [-last] [-nth=<n>]\n"
 	    "    -h          output this help message and exit\n"
 	    "    -v          output the version and exit\n"
 	    "    -S          disable sorting\n"
@@ -191,7 +204,10 @@ usage(void)
 	    "    -o          output description of selected on exit\n"
 	    "    -x          enable alternate screen\n"
 	    "    -X          disable alternate screen\n"
-	    "    -q query    supply an initial search query\n");
+	    "    -q query    supply an initial search query\n"
+            "    -first      pick first element and exit\n"
+            "    -last       pick last  element and exit\n"
+            "    -nth=<n>    pick nth   element and exit\n");
 
 	exit(1);
 }

--- a/pick.c
+++ b/pick.c
@@ -61,7 +61,7 @@ enum return_index {
 
 struct element {
         enum return_index type;
-        int pos;
+        int index;
 };
 
 struct choice {
@@ -96,6 +96,7 @@ static const char		*tty_parm1(const char *, int);
 static int			 tty_putc(int);
 static void			 tty_restore(void);
 static __dead void		 usage(void);
+static void                      print_element_at_index(void);
 
 static struct termios	 original_attributes;
 static struct {
@@ -121,8 +122,8 @@ main(int argc, char *argv[])
 	int			 output_description = 0;
 
 	setlocale(LC_CTYPE, "");
-        pick_element.type = NONE;
-        pick_element.pos  = -1;
+        pick_element.type  = NONE;
+        pick_element.index = -1;
 
         static struct option long_options[] =
         {
@@ -151,7 +152,7 @@ main(int argc, char *argv[])
 			break;
                 case 'e':
                         pick_element.type = FIRST;
-                        pick_element.pos  = 0;
+                        pick_element.index  = 0;
                         break;
                 case 'E':
                         pick_element.type = LAST;
@@ -159,7 +160,7 @@ main(int argc, char *argv[])
                         break;
                 case 'n':
                         pick_element.type = NTH;
-                        pick_element.pos  = atoi(optarg); // it returns '0' by default, which is fine
+                        pick_element.index  = atoi(optarg); // it returns '0' by default, which is fine
                         break;
 		case 'o':
 			/*
@@ -201,20 +202,24 @@ main(int argc, char *argv[])
 	}
 
 	input = get_choices();
-	tty_init();
+        if (pick_element.type == NONE) {
+	        tty_init();
 
 #ifdef HAVE_PLEDGE
 	if (pledge("stdio tty", NULL) == -1)
 		err(1, "pledge");
 #endif
 
-	choice = selected_choice();
-	tty_restore();
-	if (choice != NULL) {
-		printf("%s\n", choice->string);
-		if (output_description)
-			printf("%s\n", choice->description);
-	}
+	        choice = selected_choice();
+	        tty_restore();
+	        if (choice != NULL) {
+		        printf("%s\n", choice->string);
+		        if (output_description)
+			        printf("%s\n", choice->description);
+	        }
+        } else {
+                print_element_at_index();
+        }
 
 	free(input);
 	free(choices.v);
@@ -303,6 +308,11 @@ get_choices(void)
 	}
 
 	return buf;
+}
+
+void
+print_element_at_index(void)
+{
 }
 
 char *

--- a/pick.c
+++ b/pick.c
@@ -129,7 +129,7 @@ main(int argc, char *argv[])
 		err(1, "pledge");
 #endif
 
-	while ((c = getopt_long(argc, argv, "dhoq:SvxX", long_options, &option_index)) != -1)
+	while ((c = getopt_long(argc, argv, "dhoq:SvxXeEn:", long_options, &option_index)) != -1)
 		switch (c) {
 		case 'd':
 			descriptions = 1;

--- a/pick.c
+++ b/pick.c
@@ -53,15 +53,15 @@ enum key {
 };
 
 enum return_index {
-        NONE,
-        FIRST,
-        LAST,
-        NTH
+	NONE,
+	FIRST,
+	LAST,
+	NTH
 };
 
 struct element {
-        enum return_index type;
-        int index;
+	enum return_index type;
+	int index;
 };
 
 struct choice {
@@ -127,16 +127,16 @@ main(int argc, char *argv[])
 
         static struct option long_options[] =
         {
-                {"",        no_argument, 0, 'x'},
-                {"",        no_argument, 0, 'X'},
-                {"",        no_argument, 0, 'S'},
-                {"",        no_argument, 0, 'd'},
-                {"",        no_argument, 0, 'o'},
-                {"",        no_argument, 0, 'q'},
-                {"",        no_argument, 0, 'v'},
-                {"first",   no_argument, 0, 'e'},
-                {"last",    no_argument, 0, 'E'},
-                {"nth",     required_argument, 0, 'n'},
+                {"",	  no_argument, 0, 'x'},
+                {"",	  no_argument, 0, 'X'},
+                {"",	  no_argument, 0, 'S'},
+                {"",	  no_argument, 0, 'd'},
+                {"",	  no_argument, 0, 'o'},
+                {"",	  no_argument, 0, 'q'},
+                {"",	  no_argument, 0, 'v'},
+                {"first", no_argument, 0, 'e'},
+                {"last",  no_argument, 0, 'E'},
+                {"nth",   required_argument, 0, 'n'},
                 {0, 0, 0, 0}
         };
 
@@ -202,8 +202,8 @@ main(int argc, char *argv[])
 	}
 
 	input = get_choices();
-        if (pick_element.type == NONE) {
-	        tty_init();
+	if (pick_element.type == NONE) {
+		tty_init();
 
 #ifdef HAVE_PLEDGE
 	if (pledge("stdio tty", NULL) == -1)
@@ -213,11 +213,11 @@ main(int argc, char *argv[])
 	        choice = selected_choice();
 	        tty_restore();
         } else {
-                choice = get_choice_at_index();
+		choice = get_choice_at_index();
         }
 
 	if (choice != NULL) {
-                printf("%s\n", choice->string);
+		printf("%s\n", choice->string);
 		if (output_description)
 		printf("%s\n", choice->description);
         }
@@ -241,9 +241,9 @@ usage(void)
 	    "    -x          enable alternate screen\n"
 	    "    -X          disable alternate screen\n"
 	    "    -q query    supply an initial search query\n"
-            "    --first     pick first element and exit\n"
-            "    --last      pick last  element and exit\n"
-            "    --nth n     pick nth   element and exit\n");
+	    "    --first     pick first element and exit\n"
+	    "    --last      pick last  element and exit\n"
+	    "    --nth n     pick nth   element and exit\n");
 
 	exit(1);
 }
@@ -314,20 +314,20 @@ get_choices(void)
 const struct choice *
 get_choice_at_index(void)
 {
-        filter_choices();
-        int choices_count = print_choices(0, 0, 1);
-        if (choices_count > 0) {
-                if (pick_element.type == FIRST)
-                        return &choices.v[0];
-                else if (pick_element.type == LAST)
-                        return &choices.v[choices_count-1];
-                else if (pick_element.type == NTH) {
-                        if (pick_element.index >= 0 && pick_element.index < choices_count)
-                                return &choices.v[pick_element.index];
-                }
-        }
+	filter_choices();
+	int choices_count = print_choices(0, 0, 1);
+	if (choices_count > 0) {
+		if (pick_element.type == FIRST)
+			return &choices.v[0];
+		else if (pick_element.type == LAST)
+			return &choices.v[choices_count-1];
+		else if (pick_element.type == NTH) {
+			if (pick_element.index >= 0 && pick_element.index < choices_count)
+				return &choices.v[pick_element.index];
+		}
+	}
 
-        return NULL;
+	return NULL;
 }
 
 char *

--- a/pick.c
+++ b/pick.c
@@ -52,6 +52,13 @@ enum key {
 	PRINTABLE
 };
 
+enum return_index {
+        NONE,
+        FIRST,
+        LAST,
+        NTH
+};
+
 struct choice {
 	const char	*description;
 	const char	*string;
@@ -97,6 +104,7 @@ static size_t		 query_length, query_size;
 static int		 descriptions, choices_lines;
 static int		 sort = 1;
 static int		 use_alternate_screen = 1;
+static enum return_index rtn_idx = NONE;
 
 int
 main(int argc, char *argv[])
@@ -135,10 +143,14 @@ main(int argc, char *argv[])
 			descriptions = 1;
 			break;
                 case 'e':
+                        rtn_idx = FIRST;
+                        break;
                 case 'E':
+                        rtn_idx = LAST;
+                        break;
                 case 'n':
-                        puts("blah");
-                        exit(0);
+                        rtn_idx = NTH;
+                        break;
 		case 'o':
 			/*
 			 * Only output description if descriptions are read and

--- a/tests/57.t
+++ b/tests/57.t
@@ -1,0 +1,9 @@
+description: get first choice
+args: --first
+stdin:
+1
+2
+3
+4
+stdout:
+1

--- a/tests/58.t
+++ b/tests/58.t
@@ -1,0 +1,9 @@
+description: get last choice
+args: --last
+stdin:
+1
+2
+3
+4
+stdout:
+4

--- a/tests/59.t
+++ b/tests/59.t
@@ -1,4 +1,4 @@
-description: get first choice
+description: get nth choice
 args: --nth 2
 stdin:
 1

--- a/tests/59.t
+++ b/tests/59.t
@@ -1,0 +1,9 @@
+description: get first choice
+args: --nth 2
+stdin:
+1
+2
+3
+4
+stdout:
+2


### PR DESCRIPTION
I was using `pick` and realized that we don't always want to use it in interface mode, such as when you are including it in a script, thus:

This PR includes the flags:
  - `--first` (or `-e`): picks the first element of the list and exits
  -  `--last` (or `-E`): picks the last element of the list and exits
  - `--nth <number>` (or `-n <number>`): picks the element number `n` and exits _// the first element is the `nth` element `n=1`, the last element is the `nth` element `n=count`

Also, this PR prepares `pick` to `--long-options`, not sure if you want to use it, though.

The video below shows it better:

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/6173065/29227127-7d25c308-7e89-11e7-8145-58a9b5df6a17.gif)

_// Obs.: In spite of reading your coding spacement guide, I am not so sure about if the spaces are alright_
