### PR TITLE
Treat slash as word-delimiter in Ctrl-W

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
       tests/43.t tests/44.t tests/45.t tests/46.t tests/47.t tests/48.t \
       tests/49.t tests/50.t tests/51.t tests/52.t tests/53.t tests/54.t \
-      tests/55.t tests/56.t
+      tests/55.t tests/56.t tests/57.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=$(top_srcdir)/tests/pick-test.sh
 check_PROGRAMS=tests/pick-test

--- a/pick.c
+++ b/pick.c
@@ -409,7 +409,8 @@ selected_choice(void)
 				if (word_position < 1)
 					break;
 				if (query[word_position] != ' '
-				    && query[word_position - 1] == ' ')
+				    && (query[word_position - 1] == ' '
+				    ||  query[word_position - 1] == '/'))
 					break;
 			}
 			delete_between(

--- a/tests/57.t
+++ b/tests/57.t
@@ -1,0 +1,7 @@
+description: delete word until slash
+keys: aa/bc \027 bb \n # CTRL_W ENTER
+stdin:
+aa/bb
+aa/bc
+stdout:
+aa/bb


### PR DESCRIPTION
... otherwise a very long pathname in the query will be  completely deleted ...