### PR TITLE
Fix scrolling of long query in input field

### DIFF
--- a/pick.c
+++ b/pick.c
@@ -290,10 +290,11 @@ selected_choice(void)
 	for (;;) {
 		tty_putp(cursor_invisible, 0);
 		tty_putp(carriage_return, 1);	/* move cursor to first column */
-		if (cursor_position >= xscroll + columns)
+		if (cursor_position >= xscroll + columns ||
+		    cursor_position - columns < xscroll)
 			xscroll = cursor_position - columns + 1;
-		if (cursor_position < xscroll)
-			xscroll = cursor_position;
+		else
+			xscroll = 0;
 		print_line(&query[xscroll], query_length - xscroll, 0, -1, -1);
 		choices_count = print_choices(yscroll, selection);
 		if ((size_t)choices_count - yscroll < choices.length


### PR DESCRIPTION
How to reproduce:
```shell
echo | pick -q $( seq -s ":" 1 $COLUMNS )
```
and pressing `left arrow key` several times: nothing happens ... at some point the input field scrolls, but cursor position is out of sync and entering new characters messes up the query ...
