### PR TITLE
Set number of choices lines to display

### DIFF
--- a/pick.1
+++ b/pick.1
@@ -9,6 +9,7 @@
 .Op Fl hvS
 .Op Fl d Op Fl o
 .Op Fl x | Fl X
+.Op Fl l Ar lines
 .Op Fl q Ar query
 .Sh DESCRIPTION
 The
@@ -32,6 +33,8 @@ Both parts will be displayed but only the first part will be used when
 searching.
 .It Fl h
 Output a help message and exit.
+.It Fl l Ar lines
+Set the number of choices lines to display in the terminal.
 .It Fl o
 Output description of selected choice on exit.
 .It Fl q Ar query


### PR DESCRIPTION
... sometimes a full screen list of choices is not desired (with disabled alternate screen):
![numlines](https://user-images.githubusercontent.com/29477520/29747658-99af2dc8-8b01-11e7-8b22-d9103aa986ae.gif)
while testing the code the cursor sometimes moves to home position: as the following fixes this
```diff
@@ -318,7 +324,7 @@ selected_choice(void)
                        if (tty_putc('\n') == EOF)
                                err(1, "tty_putc");
                        tty_putp(clr_eos, 1);
-                       tty_putp(tty_parm1(parm_up_cursor, choices_count + 1),
+                       tty_putp(tty_parm1(parm_up_cursor, choices_count - yscroll + 1),
                            1);
                } else if (choices_count > 0) {
                        /*
```
I think it's a "bug" in the original code ...