### PR TITLE
Favor the shortest match

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/37.t tests/38.t tests/39.t tests/40.t tests/41.t tests/42.t \
       tests/43.t tests/44.t tests/45.t tests/46.t tests/47.t tests/48.t \
       tests/49.t tests/50.t tests/51.t tests/52.t tests/53.t tests/54.t \
-      tests/55.t tests/56.t tests/57.t
+      tests/55.t tests/56.t tests/57.t tests/58.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=$(top_srcdir)/tests/pick-test.sh
 AM_COLOR_TESTS=no

--- a/pick.c
+++ b/pick.c
@@ -596,7 +596,7 @@ min_match(const char *string, size_t offset, ssize_t *start, ssize_t *end)
 		*end = e - string;
 	}
 
-	return length;
+	return *end - *start;
 }
 
 /*

--- a/tests/58.t
+++ b/tests/58.t
@@ -1,0 +1,7 @@
+description: it favors the shortest match
+keys: aa/aa \n # ENTER
+stdin:
+aa/åå/aa
+aa/åå/aa/aa
+stdout:
+aa/åå/aa/aa


### PR DESCRIPTION
Just discovered a severe bug in the matching algorithm, please give it a
try:

> Instead of unconditionally returning the length of the current match,
> make sure the shortest match bubbles up along the recursive call stack.
> 
> Note that this bug only occurs when a choice contains multiple instances
> of the query and the right-most match is the shortest one. See the
> example below including the choice, query, match prior this commit and
> after:
> 
> ```
> Choice       Query  Before       After
> aa/åå/aa/aa  aa/aa  aa/åå/aa/aa  aa/åå/aa/aa
> 		    ^      ^           ^   ^
> 		    |------|           |---|
> ```