### PR TITLE
Explicitly handle control characters

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/43.t tests/44.t tests/45.t tests/46.t tests/47.t tests/48.t \
       tests/49.t tests/50.t tests/51.t tests/52.t tests/53.t tests/54.t \
       tests/55.t tests/56.t tests/57.t tests/58.t tests/59.t tests/60.t \
-      tests/61.t tests/62.t tests/63.t
+      tests/61.t tests/62.t tests/63.t tests/64.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=$(top_srcdir)/tests/pick-test.sh
 AM_COLOR_TESTS=no

--- a/pick.1
+++ b/pick.1
@@ -51,6 +51,11 @@ Disable the use of the alternate screen terminal feature.
 .Bl -tag -width XXXX
 .It Ic Ctrl-C
 Exit with a erroneous status without outputting the selected choice.
+While this command often being defined as Ctrl-C it is determined by the
+.Dv VINTR
+control character,
+see
+.Xr termios 4 .
 .It Ic Ctrl-L
 Redraw interface with respect to the current size of the terminal.
 .It Ic Up Ns / Ns Ic Down | Ic Ctrl-P Ns / Ns Ic Ctrl-N

--- a/tests/64.t
+++ b/tests/64.t
@@ -1,0 +1,5 @@
+description: Ctrl-C aborts without outputting the selected choice
+keys: \003 # CTRL_C
+exit: 1
+stdin:
+a


### PR DESCRIPTION
The current SIGINT handler is not considered safe since it invokes
functions that are not considered asynchronous safe[1]. Quoting the
CERT C Coding Standard:

  In general, it is not safe to invoke I/O functions from within signal
  handlers.

Instead, do not turn control characters into signal but instead handle
the relevant ones explicitly. A pleasant side-effect is being able to
test the Ctrl-C error path.

While here, fix the broken suspend/resume behavior by resetting the
initial terminal state prior suspending and re-read it upon resume. I do
actually use suspend/resume while running pick when I forgot to check
something that will affect the choice to select.

[1] https://www.securecoding.cert.org/confluence/display/c/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers