### PR TITLE
Fix broken INSTALL.md.in path while running make distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,8 @@ tests_pick_test_SOURCES=tests/pick-test.c compat-reallocarray.c
 tests_pick_test_CFLAGS=$(AM_CFLAGS)
 
 EXTRA_DIST=INSTALL.md INSTALL.md.in LICENSE README.md tests/pick-test.sh $(TESTS)
+DISTCLEANFILES=INSTALL.md
 
 INSTALL.md: INSTALL.md.in
-	sed -e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' $@.in > $@
+	sed -e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
+		$(top_srcdir)/$@.in > $@


### PR DESCRIPTION
The distcheck target ensures that the distribution tarball is
self-contained, i.e. using only the files present in the distribution it
can create another identical [distribution]. While doing so, we can't
assume that the current directory is the top-level.

This makes `make distcheck` work for me on OpenBSD. /cc @mike-burns 

[distribution]: https://www.gnu.org/software/automake/manual/automake.html#Checking-the-Distribution