### PR TITLE
Ignore OSC escape sequences

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ TESTS=tests/01.t tests/02.t tests/03.t tests/04.t tests/05.t tests/06.t \
       tests/49.t tests/50.t tests/51.t tests/52.t tests/53.t tests/54.t \
       tests/55.t tests/56.t tests/57.t tests/58.t tests/59.t tests/60.t \
       tests/61.t tests/62.t tests/63.t tests/64.t tests/65.t tests/66.t \
-      tests/67.t
+      tests/67.t tests/68.t
 TEST_EXTENSIONS=.t
 T_LOG_COMPILER=$(top_srcdir)/tests/pick-test.sh
 AM_COLOR_TESTS=no

--- a/tests/46.t
+++ b/tests/46.t
@@ -1,4 +1,4 @@
-description: do not match inside an escape sequence
+description: do not match inside a CSI escape sequence
 keys: 32 \n
 stdin:
 \033[32m33\033[m

--- a/tests/68.t
+++ b/tests/68.t
@@ -1,0 +1,7 @@
+description: do not match inside a OSC escape sequence
+keys: example \n # ENTER
+stdin:
+\033]8;;example.com\aOSC Hyperlink\e]8;;\a
+favored match since the query is not inside the escape sequence example.com
+stdout:
+favored match since the query is not inside the escape sequence example.com


### PR DESCRIPTION
It was brought to my attention that pick didn't handle OSC escape
sequences correctly. Make sure to ignore them while calculating the line
width for each choice and ignore them while matching.