### PR TITLE
Add toggle sorting key binding

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ TESTS=tests/key-alt-enter.t \
       tests/key-ctrl-e.t \
       tests/key-ctrl-k.t \
       tests/key-ctrl-l.t \
+      tests/key-ctrl-o.t \
       tests/key-ctrl-u.t \
       tests/key-ctrl-w.t \
       tests/key-del.t \

--- a/pick.1
+++ b/pick.1
@@ -45,6 +45,9 @@ Supply an initial search query.
 .It Fl S
 Disable sorting.
 Only filter the choices instead of additionally sorting by score.
+This option can be toggled from within the interface,
+see
+.Sx COMMANDS .
 .It Fl v
 Output the version and exit.
 .It Fl x
@@ -64,6 +67,8 @@ see
 .Xr termios 4 .
 .It Ic Ctrl-L
 Redraw interface with respect to the current size of the terminal.
+.It Ic Ctrl-O
+Toggle sorting.
 .It Ic Up Ns / Ns Ic Down | Ic Ctrl-P Ns / Ns Ic Ctrl-N
 Select between choices matching the current search query.
 .It Ic Page-Down Ns / Ns Ic Page-Up | Ic Ctrl-V Ns / Ns Ic Alt-V | Ic Alt-Space

--- a/pick.c
+++ b/pick.c
@@ -44,6 +44,7 @@ enum key {
 	CTRL_E,
 	CTRL_K,
 	CTRL_L,
+	CTRL_O,
 	CTRL_U,
 	CTRL_W,
 	CTRL_Z,
@@ -445,6 +446,10 @@ selected_choice(void)
 		case CTRL_L:
 			tty_size();
 			break;
+		case CTRL_O:
+			sort = !sort;
+			dofilter = 1;
+			break;
 		case CTRL_W:
 			if (cursor_position == 0)
 				break;
@@ -708,6 +713,7 @@ tty_init(int doinit)
 	new_attributes.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
 	new_attributes.c_cc[VMIN] = 1;
 	new_attributes.c_cc[VTIME] = 0;
+	new_attributes.c_cc[VDISCARD] = _POSIX_VDISABLE;
 	tcsetattr(fileno(tty_in), TCSANOW, &new_attributes);
 
 	if (doinit && (tty_out = fopen("/dev/tty", "w")) == NULL)
@@ -928,6 +934,7 @@ get_key(const char **key)
 		KEY(CTRL_E,	"\005"),
 		KEY(CTRL_K,	"\013"),
 		KEY(CTRL_L,	"\014"),
+		KEY(CTRL_O,	"\017"),
 		KEY(CTRL_U,	"\025"),
 		KEY(CTRL_W,	"\027"),
 		KEY(CTRL_W,	"\033\177"),

--- a/tests/key-ctrl-o.t
+++ b/tests/key-ctrl-o.t
@@ -1,0 +1,16 @@
+description: Ctrl-O toggles sorting
+keys: foo \017 \n # CTRL_O ENTER
+stdin:
+foo bar
+foo
+stdout:
+foo bar
+
+description: it works in conjuction with the -S option
+args: -S
+keys: foo \017 \n # CTRL_O ENTER
+stdin:
+foo bar
+foo
+stdout:
+foo


### PR DESCRIPTION
I use pick to find Git commits, a lot. I generally make use of the `-S`
option since newer commits (lines near the beginning of input) is often
more relevant than older ones with a higher score. However, it would be
convenient to be able to toggle sorting on and off.

Unfortunately, this binding conflicts with [STOP](http://man.openbsd.org/termios#VSTOP), might not be a problem
but proposals on a different binding are welcome.