### PR TITLE
Remove Werror compiler flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      env: BUILD_TYPE=default CFLAGS='-fsanitize=address -fsanitize=undefined'
+      env: BUILD_TYPE=default CFLAGS='-fsanitize=address -fsanitize=undefined -Werror'
     - os: linux
       compiler: clang-5.0
-      env: BUILD_TYPE=default CFLAGS='-fsanitize=address -fsanitize=undefined'
+      env: BUILD_TYPE=default CFLAGS='-fsanitize=address -fsanitize=undefined -Werror'
       addons:
         apt:
           sources:
@@ -21,13 +21,13 @@ matrix:
             - clang-5.0
     - os: linux
       compiler: gcc
-      env: BUILD_TYPE=default CFLAGS=-fsanitize=address
+      env: BUILD_TYPE=default CFLAGS='-fsanitize=address -Werror'
     - os: osx
       compiler: clang
-      env: BUILD_TYPE=default CFLAGS=-fsanitize=address
+      env: BUILD_TYPE=default CFLAGS='-fsanitize=address -Werror'
     - os: linux
       compiler: clang
-      env: BUILD_TYPE=coverage CFLAGS='-coverage -O0'
+      env: BUILD_TYPE=coverage CFLAGS='-coverage -O0 -Werror'
     - os: linux
       compiler: clang
       env: BUILD_TYPE=coverity

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS=foreign
 
-AM_CFLAGS=-Wall -Werror -Wextra
+AM_CFLAGS=-Wall -Wextra
 AM_CPPFLAGS=-D_GNU_SOURCE
 
 bin_PROGRAMS=pick


### PR DESCRIPTION
It's generally considered bad practice to ship software with this flag.
Issue revealed while updating the port on [OpenBSD].

[OpenBSD]: https://marc.info/?l=openbsd-ports&m=151482370923381&w=2