### PR TITLE
Trim down README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Copyright (c) 2017 Calle Erlandsson, Anton Lindqvist & thoughtbot.
 
 [crux]: https://github.com/6c37/crux-ports
 [current]: https://github.com/calleerlandsson/pick/blob/master/CONTRIBUTING.md
-[debian]: https://packages.debian.org/stretch/pick
+[debian]: https://packages.debian.org/stable/misc/pick
 [gentoo]: https://packages.gentoo.org/packages/sys-apps/pick
 [pick-vim]: https://github.com/calleerlandsson/pick.vim
 [pick]: https://calleerlandsson.github.io/pick/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
-# Pick
+# pick
 
 ![pick(1) usage](screencast.gif)
 
-The
 [pick(1)][pick]
-utility allows users to choose one option from a set of choices using an
-interface with fuzzy search functionality.
+reads a list of choices from `stdin` and outputs the selected choice to
+`stdout`.
+Therefore it is easily used both in pipelines and subshells:
+
+```sh
+# Select a file in the current directory to open using xdg-open(1):
+$ find . -type f | pick | xargs xdg-open
+# Select a command from the history to execute:
+$ eval $(fc -ln 1 | pick)
+```
+
+[pick(1)][pick] can also be used from within Vim,
+see the
+[pick.vim][pick-vim]
+plugin.
 
 ## Installation
 
@@ -77,32 +89,6 @@ Download the latest [release] and follow the bundled instructions in
 If you want to try the latest unreleased version,
 follow the instructions in [CONTRIBUTING.md][current].
 
-## Usage
-
-[pick(1)][pick]
-reads a list of choices on `stdin` and outputs the selected choice on `stdout`.
-Therefore it is easily used both in pipelines and subshells:
-
-```sh
-git ls-files | pick | xargs less # Select a file in the current git repository to view in less
-cd "$(find . -type d | pick)"    # Select a directory to cd into
-eval $(fc -ln 1 | pick)          # Select a command from the history to execute
-```
-
-Pick can also easily be used from within Vim both using `system()` and `!`. For
-ready-to-map functions, see [the pick.vim Vim plugin]. For examples of how to
-call `pick(1)` from within Vim, see [the pick.vim source code].
-
-***Please note:*** pick requires a fully functional terminal to run and
-therefore cannot be run from within gvim or MacVim.
-
-See the
-[pick(1)][pick]
-man page for detailed usage instructions and more examples.
-
-[the pick.vim Vim plugin]: https://github.com/calleerlandsson/pick.vim/
-[the pick.vim source code]: https://github.com/calleerlandsson/pick.vim/blob/master/plugin/pick.vim
-
 ## Copyright
 
 Copyright (c) 2017 Calle Erlandsson, Anton Lindqvist & thoughtbot.
@@ -111,7 +97,8 @@ Copyright (c) 2017 Calle Erlandsson, Anton Lindqvist & thoughtbot.
 [current]: https://github.com/calleerlandsson/pick/blob/master/CONTRIBUTING.md
 [debian]: https://packages.debian.org/stretch/pick
 [gentoo]: https://packages.gentoo.org/packages/sys-apps/pick
-[pick]: https://mptre.github.io/pick.1
+[pick-vim]: https://github.com/calleerlandsson/pick.vim
+[pick]: https://calleerlandsson.github.io/pick/
 [release]: https://github.com/calleerlandsson/pick/releases/
 [ubuntu]: https://packages.ubuntu.com/xenial/pick
 [void]: https://github.com/voidlinux/void-packages/blob/master/srcpkgs/pick/template


### PR DESCRIPTION
- Merge the initial paragraph with usage, now that we can refer to manual

- Limitations of calling pick from within Vim is better of described in the
  README of pick.vim

/cc @calleerlandsson @teoljungberg @mike-burns 