### PR TITLE
Favor LC_ALL over LC_CTYPE in pick-test

### DIFF
--- a/tests/pick-test.c
+++ b/tests/pick-test.c
@@ -26,7 +26,7 @@ static char		**pickargv;
  * Any existing value will be overwritten.
  */
 static const char	 *pickenv[] = {
-	"LC_CTYPE",		"en_US.UTF-8",
+	"LC_ALL",		"en_US.UTF-8",
 	"MALLOC_OPTIONS",	"RS",		/* malloc.conf(5) options on OpenBSD */
 	"TERM",			"xterm",
 	NULL,


### PR DESCRIPTION
Fixes #281.

@DBOTW or @giappi could you please verify that this works as intended on Arch Linux?